### PR TITLE
#1 Session Stats are not updated

### DIFF
--- a/internal/pkg/httpsrv/server.go
+++ b/internal/pkg/httpsrv/server.go
@@ -19,7 +19,7 @@ type Server struct {
 	server       *http.Server                // Gorilla HTTP server.
 	watchers     map[string]*watcher.Watcher // Counter watchers (k: counterId).
 	watchersLock *sync.RWMutex               // Counter lock.
-	sessionStats []sessionStats              // Session stats.
+	sessionStats []*sessionStats             // Session stats.
 	quitChannel  chan struct{}               // Quit channel.
 	running      sync.WaitGroup              // Running goroutines.
 }
@@ -30,7 +30,7 @@ func New(strChan <-chan string) *Server {
 	s.server = nil // Set below.
 	s.watchers = make(map[string]*watcher.Watcher)
 	s.watchersLock = &sync.RWMutex{}
-	s.sessionStats = []sessionStats{}
+	s.sessionStats = []*sessionStats{}
 	s.quitChannel = make(chan struct{})
 	s.running = sync.WaitGroup{}
 	return &s

--- a/internal/pkg/httpsrv/stats.go
+++ b/internal/pkg/httpsrv/stats.go
@@ -24,5 +24,5 @@ func (s *Server) incStats(id string) {
 		}
 	}
 	// Not found, add new.
-	s.sessionStats = append(s.sessionStats, sessionStats{id: id, sent: 1})
+	s.sessionStats = append(s.sessionStats, &sessionStats{id: id, sent: 1})
 }


### PR DESCRIPTION
The error happens because in `Server.incStats()` we get a copy of the `sessionStats` slice's `sessionStats` struct.
We then modify this copy which does not affect the `sessionStats` struct residing in slice `Server.sessionStats`.

With this solution `Server.sessionStats` slice will store references of `sessionStats` structs.
Thus when iterating the slice we will get a reference to the struct rather than a copy and we will modify the slice's struct.