### PR TITLE
#1 Session Stats are not updated

### DIFF
--- a/internal/pkg/httpsrv/stats.go
+++ b/internal/pkg/httpsrv/stats.go
@@ -17,9 +17,9 @@ func (w *sessionStats) inc() {
 
 func (s *Server) incStats(id string) {
 	// Find and increment.
-	for _, ws := range s.sessionStats {
-		if ws.id == id {
-			ws.inc()
+	for i := range s.sessionStats {
+		if s.sessionStats[i].id == id {
+			s.sessionStats[i].inc()
 			return
 		}
 	}


### PR DESCRIPTION
The error happens because in `Server.incStats()` we get a copy of the `sessionStats` slice's `sessionStats` struct.
We then modify this copy which does not affect the `sessionStats` struct residing in slice `Server.sessionStats`.

With this solution in `Server.incStats()` we will use index iterating in order to affect the slice's struct instead of its copy.