### PR TITLE
#5 use default CheckOrigin

### DIFF
--- a/internal/pkg/httpsrv/handler_websocket.go
+++ b/internal/pkg/httpsrv/handler_websocket.go
@@ -24,11 +24,7 @@ func (s *Server) handlerWebSocket(w http.ResponseWriter, r *http.Request) {
 	defer s.removeWatcher(watch)
 
 	// Start WS.
-	var upgrader = websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
-	}
+	var upgrader = websocket.Upgrader{}
 
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {


### PR DESCRIPTION
As it currently stands, `CheckOrigin` when doing a websocket upgrade does not provide any check regarding the `Origin` header. Solution to this is to use the default `CheckOrigin` provided by the `websocket` module, which checks the `Origin` header against the `Host` header.

This function could be enhanced according to requirements on a new feature request.