### PR TITLE
Feature C: Client CLI

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -15,7 +15,7 @@ import (
 func StartConnection(id int, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	log := log.New(os.Stdout, fmt.Sprintf("[conn #%d] ", id), log.Lmsgprefix)
+	log := log.New(os.Stdout, fmt.Sprintf("[conn #%d] ", id), log.LstdFlags|log.Lmsgprefix)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net/url"
@@ -10,8 +11,6 @@ import (
 
 	"github.com/gorilla/websocket"
 )
-
-const totalConnections = 3
 
 func StartConnection(id int, wg *sync.WaitGroup) {
 	defer wg.Done()
@@ -65,13 +64,14 @@ func StartConnection(id int, wg *sync.WaitGroup) {
 }
 
 func main() {
-
-	fmt.Println("Started WS client")
+	totalConnections := flag.Int("n", 1, "Number of WebSocket connections to initiate")
+	flag.Parse()
+	log.Printf("Started WS client with %d connections\n", *totalConnections)
 
 	// Wait for all connections to finish
 	var wg sync.WaitGroup
 
-	for i := 1; i <= totalConnections; i++ {
+	for i := 1; i <= *totalConnections; i++ {
 		wg.Add(1)
 		go StartConnection(i, &wg)
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+
+	"github.com/gorilla/websocket"
+)
+
+func main() {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	fmt.Println("Started WS client")
+
+	url := url.URL{
+		Scheme: "ws",
+		Host:   "localhost:8080",
+		Path:   "goapp/ws",
+	}
+
+	log.Printf("connecting to %s", url.String())
+
+	c, _, err := websocket.DefaultDialer.Dial(url.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+	defer c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			_, message, err := c.ReadMessage()
+			if err != nil {
+				log.Println("read:", err)
+				return
+			}
+			log.Printf("recv: %s", message)
+		}
+	}()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-interrupt:
+			log.Println("interrupt")
+
+			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			if err != nil {
+				log.Println("write close:", err)
+				return
+			}
+
+			<-done
+			log.Println("Read closed")
+			return
+		}
+	}
+
+}


### PR DESCRIPTION
https://github.com/christos27/goapp/issues/16
https://github.com/christos27/goapp/issues/17
https://github.com/christos27/goapp/issues/18

Create a command line client as a separate application that opens a requested number of sessions simultaneously.

This should be a separate executable generated with the `make` command in the `bin/` folder that will accept an argument with the number of parallel connections that will open on the server.